### PR TITLE
iOS Launch Storyboard with single-image launch screen target

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ var getPlatforms = function () {
   var platforms = [];
   var cordovaProjectRoot = path.dirname(settings.CONFIG_FILE);
   var xcodeFolder = 'Images.xcassets/LaunchImage.launchimage';
+  var xcodeStoryboardFolder = 'Images.xcassets/LaunchStoryboard.imageset';
   var androidFolder = 'app/src/main/res';
   var windowsFolder = 'images';
 
@@ -70,6 +71,13 @@ var getPlatforms = function () {
       { name: 'Default-Portrait@2x~ipad.png',  width: 1536, height: 2048 },
       { name: 'Default-Landscape~ipad.png',    width: 1024, height: 768  },
       { name: 'Default-Landscape@2x~ipad.png', width: 2048, height: 1536 }
+    ]
+  });
+  platforms.push({
+    name: 'ios-storyboard',
+    splashPattern: path.join(cordovaProjectRoot, 'platforms/ios', '*', xcodeStoryboardFolder),
+    splashes: [
+      { name: 'Default@2x~universal~anyany.png', width: 2732, height: 2732 }
     ]
   });
   platforms.push({


### PR DESCRIPTION
Up to _cordova-ios_ 5, both Launch Image and Launch Storyboard folders were available in the generated Xcode project.
But since _cordova-ios_ 6, only the Launch Storyboard remains, as the other one is deprecated.

For docs about Cordova and Launch Storyboard see https://github.com/apache/cordova-plugin-splashscreen#ios-specific-information.

---
**Here** is the _"easiest"_ solution providing a [single universal image](https://github.com/apache/cordova-plugin-splashscreen#single-image-launch-screen).

Future versions could deal with more sizes, idioms, or dark-mode, following some original PRs like AlexDisler#55 and AlexDisler#57
... we'll see :)